### PR TITLE
set qps and burst values used by migrator

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -23,6 +23,8 @@ spec:
           - migrator
           - '--alsologtostderr'
           - '--v=2'
+          - '--kube-api-qps=30'
+          - '--kube-api-burst=40'
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
             requests:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -73,6 +73,8 @@ spec:
           - migrator
           - '--alsologtostderr'
           - '--v=2'
+          - '--kube-api-qps=30'
+          - '--kube-api-burst=40'
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
             requests:


### PR DESCRIPTION
Configure the values of QPS and Burst used by API Server clients in `kube-storage-version-migrator`

Requires https://github.com/kubernetes-sigs/kube-storage-version-migrator/pull/54

cc @sttts  @sanchezl 