### PR TITLE
Bug 1822943: return sync error to add to queue

### DIFF
--- a/pkg/operator/targetcontroller/controller.go
+++ b/pkg/operator/targetcontroller/controller.go
@@ -95,7 +95,10 @@ func (c *TargetController) sync() error {
 	}
 
 	forceRequeue, err := c.syncKubeStorageVersionMigrator(spec, status, objectMetaGeneration)
-	if forceRequeue && err != nil {
+	if err != nil {
+		return err
+	}
+	if forceRequeue {
 		c.queue.AddRateLimited(workQueueKey)
 	}
 

--- a/pkg/operator/targetcontroller/sync_test.go
+++ b/pkg/operator/targetcontroller/sync_test.go
@@ -1,6 +1,7 @@
 package targetcontroller
 
 import (
+	"fmt"
 	v12 "github.com/openshift/api/operator/v1"
 	v1 "k8s.io/api/apps/v1"
 	v13 "k8s.io/api/core/v1"
@@ -66,6 +67,18 @@ func TestManageOperatorStatusProgressing(t *testing.T) {
 			ObservedGeneration: 1,
 		},
 	}
-	manageOperatorStatusProgressing(deployment, status, 1)
+	manageOperatorStatusProgressing(deployment, nil, status, 1)
+	t.Log(mergepatch.ToYAMLOrError(status))
+}
+
+func TestManageOperatorStatusProgressingSyncErr(t *testing.T) {
+	var errors []error
+	errors = append(errors, fmt.Errorf("syncErr"))
+	var statusTrue v12.ConditionStatus = "True"
+	status := &v12.KubeStorageVersionMigratorStatus{}
+	manageOperatorStatusProgressing(nil, errors, status, 1)
+	if status.OperatorStatus.Conditions[0].Status != statusTrue {
+		t.Errorf("Expected Progressing %v, got %v", statusTrue, status.OperatorStatus.Conditions[0].Status)
+	}
 	t.Log(mergepatch.ToYAMLOrError(status))
 }


### PR DESCRIPTION
When sync errors encountered, nothing is added to queue, so operator is stuck until operator pod refreshed.  This PR ensures resync upon error.   