### PR TITLE
Bug 1809397: oc explain storagestates and storageversionmigrations with empty DESCRIPTION

### DIFF
--- a/manifests/0000_40_kube-storage-version-migrator-operator_01_storage_migration_crd.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_01_storage_migration_crd.yaml
@@ -12,6 +12,7 @@ spec:
     plural: storageversionmigrations
     singular: storageversionmigration
   scope: Cluster
+  preserveUnknownFields: false
   subresources:
     status: {}
   version: v1alpha1

--- a/manifests/0000_40_kube-storage-version-migrator-operator_01_storage_state_crd.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_01_storage_state_crd.yaml
@@ -12,6 +12,7 @@ spec:
     plural: storagestates
     singular: storagestate
   scope: Cluster
+  preserveUnknownFields: false
   subresources:
     status: {}
   version: v1alpha1
@@ -35,7 +36,6 @@ spec:
           submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
-          description: The name must be "<.spec.resource.resouce>.<.spec.resource.group>".
           type: object
         spec:
           description: Specification of the storage state.


### PR DESCRIPTION
When defining a CRD using the apiextensions.k8s.io/v1beta1 CustomResourceDefinition API, `preserveUnknownFields` defaults to `true`, which suppresses the publishing of the openapi validation schema. 