### PR TITLE
Bug 1881938: migrator deployment doesn't tolerate masters 

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -28,3 +28,15 @@ spec:
             requests:
               cpu: 100m
               memory: 200Mi
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 120
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 120

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -87,6 +87,18 @@ spec:
             requests:
               cpu: 100m
               memory: 200Mi
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 120
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 120
 `)
 
 func kubeStorageVersionMigratorDeploymentYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Tolerate running migrator pod on master nodes. 

Ideally migrator should be running on a master node, but I'm not forcing it to with this PR due to past issues with the memory requirements that make it harder to schedule the migrator pod.