### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_40_kube-storage-version-migrator-operator_01_storage_migration_crd.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_01_storage_migration_crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api-approved.kubernetes.io: "unapproved"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: migration.k8s.io
   names:

--- a/manifests/0000_40_kube-storage-version-migrator-operator_01_storage_state_crd.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_01_storage_state_crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api-approved.kubernetes.io: "unapproved"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: migration.k8s.io
   names:

--- a/manifests/0000_40_kube-storage-version-migrator-operator_02_namespace.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_02_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-kube-storage-version-migrator-operator

--- a/manifests/0000_40_kube-storage-version-migrator-operator_03_configmap.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_03_configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1

--- a/manifests/0000_40_kube-storage-version-migrator-operator_04_serviceaccount.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_04_serviceaccount.yaml
@@ -8,3 +8,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/0000_40_kube-storage-version-migrator-operator_05_roles.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_05_roles.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_40_kube-storage-version-migrator-operator_06_operatorconfig.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_06_operatorconfig.yaml
@@ -6,5 +6,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/0000_40_kube-storage-version-migrator-operator_07_deployment.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_07_deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   strategy:

--- a/manifests/0000_40_kube-storage-version-migrator-operator_08_service.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_08_service.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: kube-storage-version-migrator-operator
   name: metrics

--- a/manifests/0000_40_kube-storage-version-migrator-operator_09_clusteroperator.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_09_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:
   versions:


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.