### PR TITLE
Bug 1920159: CPU request for migrator should not be higher than average use

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -26,5 +26,5 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
             requests:
-              cpu: 100m
+              cpu: 10m
               memory: 200Mi

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -85,7 +85,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
             requests:
-              cpu: 100m
+              cpu: 10m
               memory: 200Mi
 `)
 


### PR DESCRIPTION
The migrator is always running and does not consume 100mc, which is against
our policy for out of the box components. The pod is still burstable
which does not prevent excess CPU from being consumed, but components are
not allowed to significantly overstate their steady state CPU. A future
alternative is for the operator to only run the migrator when necessary,
in which case the CPU and memory use can be increased to be consistent
with use during runtime.

/hold

while we review all the PRs together