### PR TITLE
README: Stub in brief purpose docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# cluster-kube-storage-version-migrator-operator
+# kube-storage-version-migrator operator
+
+This operator manages the [kube-storage-version-migrator][migrator], which:
+
+* Detects changes of the default storage version of a resource type by polling the API server's discovery document.
+* Creates migration requests for resource types whose storage version changes.
+* Processes migration requests by geting all objects of the migrated type and writing them back the API server without modification.  The purpose is to trigger the API server to encode the object in the latest storage version before storing it.
+
+[migrator]: https://github.com/openshift/kubernetes-kube-storage-version-migrator


### PR DESCRIPTION
Would be nice to have the README include (links to) collaboration notes and security issue reporting and all that.  But I'm not clear on what the operator maintainers want to use for that stuff, so this commit just brings over and tweaks a bit of text from [here][1] so folks wondering "what is this about?" don't have to think too hard.

[1]: https://github.com/openshift/kubernetes-kube-storage-version-migrator/blob/481bd04dbc78c29dad05deba0309e049fa26e4d9/USER_GUIDE.md#storage-version-migrator-in-a-nutshell