### PR TITLE
Bug 1935347: bindata/kube-storage-version-migrator/deployment: Tolerate master

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -28,3 +28,7 @@ spec:
             requests:
               cpu: 10m
               memory: 200Mi
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -87,6 +87,10 @@ spec:
             requests:
               cpu: 10m
               memory: 200Mi
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
 `)
 
 func kubeStorageVersionMigratorDeploymentYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This complies with [our conventions][1], and allows the operand to still schedule in cases where compute has been scaled to zero.  We still allow scheduling on compute, when the scheduler feels like that's where the spare capacity is, although the operand isn't a big resource hog.

[1]: https://github.com/openshift/enhancements/blob/8f0b938aceb69ee6f0767d4e8f1e0ac9789e2afe/CONVENTIONS.md#taints-and-tolerations