### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       app: migrator
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: migrator
     spec:

--- a/bindata/kube-storage-version-migrator/namespace.yaml
+++ b/bindata/kube-storage-version-migrator/namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-kube-storage-version-migrator
+  annotations:
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_40_kube-storage-version-migrator-operator_02_namespace.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_02_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-kube-storage-version-migrator-operator

--- a/manifests/0000_40_kube-storage-version-migrator-operator_07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_07_deployment-ibm-cloud-managed.yaml
@@ -17,6 +17,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-storage-version-migrator-operator
       name: kube-storage-version-migrator-operator

--- a/manifests/0000_40_kube-storage-version-migrator-operator_07_deployment.yaml
+++ b/manifests/0000_40_kube-storage-version-migrator-operator_07_deployment.yaml
@@ -17,6 +17,8 @@ spec:
   template:
     metadata:
       name: kube-storage-version-migrator-operator
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-storage-version-migrator-operator
     spec:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -71,6 +71,8 @@ spec:
       app: migrator
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: migrator
     spec:
@@ -120,8 +122,11 @@ var _kubeStorageVersionMigratorNamespaceYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-kube-storage-version-migrator
+  annotations:
+    workload.openshift.io/allowed: "management"
   labels:
-    openshift.io/cluster-monitoring: "true"`)
+    openshift.io/cluster-monitoring: "true"
+`)
 
 func kubeStorageVersionMigratorNamespaceYamlBytes() ([]byte, error) {
 	return _kubeStorageVersionMigratorNamespaceYaml, nil


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.