### PR TITLE
Bug 1928141: kube-storage-version-migrator constantly reporting type "Upgradeable" status Unknown

### DIFF
--- a/pkg/operator/targetcontroller/sync.go
+++ b/pkg/operator/targetcontroller/sync.go
@@ -87,7 +87,7 @@ func manageOperatorStatusUpgradeable(status *operatorv1.KubeStorageVersionMigrat
 	// Create a default condition to avoid status controller from assuming 'Upgradeable=Unknown'.
 	// No known reasons to set Upgradeable=False as of this date.
 	v1helpers.SetOperatorCondition(&status.Conditions, operatorv1.OperatorCondition{
-		Type:   "DefaultUpgradable",
+		Type:   "DefaultUpgradeable",
 		Status: operatorv1.ConditionTrue,
 		Reason: "Default",
 	})

--- a/pkg/operator/targetcontroller/sync_test.go
+++ b/pkg/operator/targetcontroller/sync_test.go
@@ -2,12 +2,14 @@ package targetcontroller
 
 import (
 	"fmt"
-	v12 "github.com/openshift/api/operator/v1"
-	v1 "k8s.io/api/apps/v1"
-	v13 "k8s.io/api/core/v1"
-	v14 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/mergepatch"
+	"strings"
 	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
 )
 
 func TestResolveImageReference(t *testing.T) {
@@ -15,16 +17,16 @@ func TestResolveImageReference(t *testing.T) {
 		imagePullSpec:         "image-pull:spec",
 		operatorImagePullSpec: "operator-image-pull:spec",
 	}
-	deployment := v1.Deployment{
-		Spec: v1.DeploymentSpec{
-			Template: v13.PodTemplateSpec{
-				Spec: v13.PodSpec{
-					InitContainers: []v13.Container{
+	deployment := appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
 						{
 							Image: "${IMAGE}",
 						},
 					},
-					Containers: []v13.Container{
+					Containers: []corev1.Container{
 						{
 							Image: "${IMAGE}",
 						},
@@ -43,27 +45,27 @@ func TestResolveImageReference(t *testing.T) {
 }
 
 func TestManageOperatorStatusAvailable(t *testing.T) {
-	deployment := &v1.Deployment{
-		Status: v1.DeploymentStatus{
+	deployment := &appsv1.Deployment{
+		Status: appsv1.DeploymentStatus{
 			AvailableReplicas: 1,
 		},
 	}
-	status := &v12.KubeStorageVersionMigratorStatus{}
+	status := &operatorv1.KubeStorageVersionMigratorStatus{}
 	manageOperatorStatusAvailable(deployment, status)
 	t.Log(mergepatch.ToYAMLOrError(status))
 }
 
 func TestManageOperatorStatusProgressing(t *testing.T) {
-	deployment := &v1.Deployment{
-		ObjectMeta: v14.ObjectMeta{
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
 			Generation: 1,
 		},
-		Status: v1.DeploymentStatus{
+		Status: appsv1.DeploymentStatus{
 			ObservedGeneration: 1,
 		},
 	}
-	status := &v12.KubeStorageVersionMigratorStatus{
-		OperatorStatus: v12.OperatorStatus{
+	status := &operatorv1.KubeStorageVersionMigratorStatus{
+		OperatorStatus: operatorv1.OperatorStatus{
 			ObservedGeneration: 1,
 		},
 	}
@@ -71,11 +73,26 @@ func TestManageOperatorStatusProgressing(t *testing.T) {
 	t.Log(mergepatch.ToYAMLOrError(status))
 }
 
+func TestManageOperatorStatusUpgradeable(t *testing.T) {
+	status := &operatorv1.KubeStorageVersionMigratorStatus{}
+	manageOperatorStatusUpgradeable(status)
+	if !strings.HasSuffix(status.Conditions[0].Type, operatorv1.OperatorStatusTypeUpgradeable) {
+		t.Errorf("expecting an Upgradeable condition")
+	}
+	if status.Conditions[0].Status != operatorv1.ConditionTrue {
+		t.Errorf("expecting condition status to be %q", operatorv1.ConditionTrue)
+	}
+	if t.Failed() {
+		t.Log(mergepatch.ToYAMLOrError(status))
+	}
+
+}
+
 func TestManageOperatorStatusProgressingSyncErr(t *testing.T) {
 	var errors []error
 	errors = append(errors, fmt.Errorf("syncErr"))
-	var statusTrue v12.ConditionStatus = "True"
-	status := &v12.KubeStorageVersionMigratorStatus{}
+	var statusTrue operatorv1.ConditionStatus = "True"
+	status := &operatorv1.KubeStorageVersionMigratorStatus{}
 	manageOperatorStatusProgressing(nil, errors, status, 1)
 	if status.OperatorStatus.Conditions[0].Status != statusTrue {
 		t.Errorf("Expected Progressing %v, got %v", statusTrue, status.OperatorStatus.Conditions[0].Status)


### PR DESCRIPTION
Typo was preventing proper union of upgradeable statuses.