### PR TITLE
[release-4.8] Bug 2022844: Extensive number of requests from storage version operator in cluster – Part 1

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,5 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.14
+


### PR DESCRIPTION
I need to move this operator from `go1.14` to go `1.16`, otherwise it cannot consume updated deps when fixing bugs that depend on `go1.16` (specifically `client-go` uses the `io/fs` pkg from `go1.16`).

Plan:
1. introduce `.ci_operator.yaml` (this PR)
2. update ci-operator job to `build_root.from_repository: true`
3. update `.ci_operator.yaml` to use go1.16
4. finish the backport of #73 