### PR TITLE
bindata: comply to restricted pod security level

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: migrator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kube-storage-version-migrator-sa
       containers:
       - name: migrator
@@ -31,7 +35,11 @@ spec:
               cpu: 10m
               memory: 200Mi
         securityContext:
-          runAsUser: 1001
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsUser: 1001          
       priorityClassName: system-cluster-critical
       tolerations:
         - key: node-role.kubernetes.io/master


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-kube-storage-version-migrator/pods/",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"migrator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"migrator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"migrator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"migrator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 