### PR TITLE
Revert "specify master node selector on migrator pod"

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -53,5 +53,3 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 120
-      nodeSelector:
-        node-role.kubernetes.io/master: ""


### PR DESCRIPTION
Reverts #92 > ; tracked by [OCPBUGS-18125](https://issues.redhat.com/browse/OCPBUGS-18125)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This change has broken hypershift, and it is no longer installing.  Hypershift fails on

```
error is version False True 30m Unable to apply 4.14.0-0.nightly-2023-08-25-105956: the cluster operator kube-storage-version-migrator is not available
```

It seems the deployment never succeeds:

```
 - lastTransitionTime: "2023-08-25T11:27:43Z"
    message: 'KubeStorageVersionMigratorProgressing: Waiting for Deployment to deploy
      pods'
    reason: KubeStorageVersionMigrator_Deploying
    status: "True"
    type: Progressing
  - lastTransitionTime: "2023-08-25T11:27:43Z"
    message: 'KubeStorageVersionMigratorAvailable: Waiting for Deployment'
    reason: KubeStorageVersionMigrator_Deploying
    status: "False"
```

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please check a hypershift job and ensure it succeeds.


CC: @sanchezl, @wangke19
