### PR TITLE
OCPBUGS-29567: Apply hypershift cluster-profile for ibm-cloud-managed

### DIFF
--- a/manifests/01_storage_migration_crd.yaml
+++ b/manifests/01_storage_migration_crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: storageversionmigrations.migration.k8s.io
   annotations:
     "api-approved.kubernetes.io": "https://github.com/kubernetes/community/pull/2524"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:

--- a/manifests/01_storage_state_crd.yaml
+++ b/manifests/01_storage_state_crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/747
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: storagestates.migration.k8s.io

--- a/manifests/02_namespace.yaml
+++ b/manifests/02_namespace.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   namespace: openshift-kube-storage-version-migrator-operator
   name: config
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 data:

--- a/manifests/04_serviceaccount.yaml
+++ b/manifests/04_serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
   labels:
     app: kube-storage-version-migrator-operator
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/manifests/05_roles.yaml
+++ b/manifests/05_roles.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   name: system:openshift:operator:kube-storage-version-migrator-operator
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:

--- a/manifests/06_operatorconfig.yaml
+++ b/manifests/06_operatorconfig.yaml
@@ -3,6 +3,7 @@ kind: KubeStorageVersionMigrator
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
   labels:
     app: kube-storage-version-migrator-operator

--- a/manifests/08_service.yaml
+++ b/manifests/08_service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert

--- a/manifests/09_clusteroperator.yaml
+++ b/manifests/09_clusteroperator.yaml
@@ -3,6 +3,7 @@ kind: ClusterOperator
 metadata:
   name: kube-storage-version-migrator
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec: {}

--- a/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/07_deployment.yaml-patch
@@ -1,6 +1,7 @@
 - op: replace
   path: /metadata/annotations
   value:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
 - op: remove
   path: /spec/template/spec/nodeSelector


### PR DESCRIPTION
Since HyperShift / Hosted Control Plane have adopted include.release.openshift.io/ibm-cloud-managed, to tailor the resources of clusters running in the ROKS IBM environment, the include.release.openshift.io/hypershift addition will allow Hypershift to express different profile choices than ROKS