### PR TITLE
[release-4.15] OCPBUGS-36322: Set required-scc for openshift workloads

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: nonroot-v2
       labels:
         app: migrator
     spec:

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: nonroot-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: kube-storage-version-migrator-operator

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -19,6 +19,7 @@ spec:
       name: kube-storage-version-migrator-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: nonroot-v2
       labels:
         app: kube-storage-version-migrator-operator
     spec:


### PR DESCRIPTION
[OCPBUGS-36322](https://issues.redhat.com/browse/OCPBUGS-36322
)
Manual cherry-pick of [#107](https://github.com/openshift/cluster-kube-storage-version-migrator-operator/pull/107)