### PR TITLE
OCPBUGS-37776: component readiness regression: unexpected state transitions during e2e test run

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -6,17 +6,17 @@ metadata:
   labels:
     app: migrator
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
-      app: migrator
+      app: kube-storage-version-migration-migrator
   template:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: nonroot-v2
       labels:
-        app: migrator
+        app: kube-storage-version-migration-migrator
     spec:
       securityContext:
         runAsNonRoot: true
@@ -54,3 +54,10 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 120
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: kube-storage-version-migration-migrator
+              topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Increase replica count of storage-version-migration migrator for HA.

Ideally, this would require https://github.com/openshift/kubernetes-kube-storage-version-migrator/pull/206, but other than the possible redundant cpu/api load it works well without it.