### PR TITLE
NO-JIRA: operator/starter.go: don't report an error on shutdown

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -119,5 +118,5 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	go loggingController.Run(ctx, 1)
 
 	<-ctx.Done()
-	return fmt.Errorf("stopped")
+	return nil
 }


### PR DESCRIPTION
termination is a normal operation and shouldn't cause any errors. the library-go framework might interpret errors and exit prematurely.

note that this fix does not make the operator exit gracefully. 
this fix will also not make [the operator release the lease gracefully.](https://github.com/openshift/cluster-kube-apiserver-operator/blob/5b21d79597009195978c3746d0fb15bd2103525b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go#L392)

@deads2k since the lease is acquired by the lib-go code I think we could ensure it would wait until the lease was cleaned up.