### PR TITLE
OCPBUGS-20062: "gracefully" shutdown KSVM pod. 

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -26,8 +26,12 @@ spec:
       containers:
       - name: migrator
         image: ${IMAGE}
-        command:
-          - migrator
+        command: [ "/bin/bash", "-c"]
+        args:
+          - |-
+            trap 'echo "Termination signal received, but ignored. Continuing..."; sleep infinity' TERM
+            migrator "$@" & wait $!
+          - bash
           - '--alsologtostderr'
           - '--v=2'
         terminationMessagePolicy: FallbackToLogsOnError

--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -40,7 +40,25 @@ spec:
           capabilities:
             drop:
             - ALL
-          runAsUser: 1001          
+          runAsUser: 1001
+      - name: graceful-termination
+        image: ${IMAGE}
+        command: [ "/bin/bash", "-c" ]
+        args:
+          - |-
+            trap 'echo "Gracefully sleeping for 25s to let another pod start..."; sleep 25; exit' EXIT
+            while true; do echo "Waiting for termination..."; sleep 3600 & wait $!; done
+        terminationMessagePolicy: FallbackToLogsOnError
+        resources:
+          requests:
+            cpu: 1m
+            memory: 1Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsUser: 1001
       priorityClassName: system-cluster-critical
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -54,3 +72,4 @@ spec:
           operator: Exists
           effect: NoExecute
           tolerationSeconds: 120
+      terminationGracePeriodSeconds: 30

--- a/pkg/operator/deploymentcontroller/deployment_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_test.go
@@ -12,29 +12,55 @@ import (
 func Test_setOperandLogLevel(t *testing.T) {
 
 	testCases := []struct {
+		name     string
 		logLevel operatorv1.LogLevel
 		command  []string
+		args     []string
 		expected []string
 	}{
 		{
+			name:     "CmdAppend",
 			logLevel: operatorv1.Debug,
 			command:  []string{"arg0", "arg1", "arg2"},
 			expected: []string{"arg0", "arg1", "arg2", "--v=4"},
 		},
 		{
+			name:     "CmdReplaceMid",
 			logLevel: operatorv1.Trace,
 			command:  []string{"arg0", "--v=2", "arg2"},
 			expected: []string{"arg0", "--v=6", "arg2"},
 		},
 		{
+			name:     "CmdReplaceEnd",
 			logLevel: operatorv1.TraceAll,
 			command:  []string{"arg0", "arg1", "--v=2"},
 			expected: []string{"arg0", "arg1", "--v=8"},
 		},
+		{
+			name:     "ArgsAppend",
+			logLevel: operatorv1.Debug,
+			command:  []string{"arg0"},
+			args:     []string{"arg1", "arg2", "arg3"},
+			expected: []string{"arg0", "arg1", "arg2", "arg3", "--v=4"},
+		},
+		{
+			name:     "ArgsReplaceMid",
+			logLevel: operatorv1.Trace,
+			command:  []string{"arg0"},
+			args:     []string{"arg1", "--v=2", "arg3"},
+			expected: []string{"arg0", "arg1", "--v=6", "arg3"},
+		},
+		{
+			name:     "ArgsReplaceEnd",
+			logLevel: operatorv1.TraceAll,
+			command:  []string{"arg0"},
+			args:     []string{"arg1", "arg2", "--v=2"},
+			expected: []string{"arg0", "arg1", "arg2", "--v=8"},
+		},
 	}
 
 	for _, tc := range testCases {
-		t.Run("", func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			spec := &operatorv1.OperatorSpec{
 				LogLevel: tc.logLevel,
 			}
@@ -43,17 +69,20 @@ func Test_setOperandLogLevel(t *testing.T) {
 					Containers: []corev1.Container{{
 						Name:    "migrator",
 						Command: tc.command,
+						Args:    tc.args,
 					}},
 				}}},
 			}
 			_ = setOperandLogLevel(spec, deployment)
-			if !cmp.Equal(deployment.Spec.Template.Spec.Containers[0].Command, tc.expected) {
-				t.Fatal(cmp.Diff(deployment.Spec.Template.Spec.Containers[0].Command, tc.expected))
+			c := deployment.Spec.Template.Spec.Containers[0]
+			actual := append(append([]string{}, c.Command...), c.Args...)
+			if !cmp.Equal(tc.expected, actual) {
+				t.Fatal(cmp.Diff(tc.expected, actual))
 			}
 		})
 	}
 
-	t.Run("", func(t *testing.T) {
+	t.Run("OtherContainer", func(t *testing.T) {
 		spec := &operatorv1.OperatorSpec{LogLevel: operatorv1.Debug}
 		deployment := &appsv1.Deployment{
 			Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{


### PR DESCRIPTION
Add a sidecar container that, in combination with an appropriate `terminationGracePeriodSeconds` setting on the pod, keeps a terminating pod around until its replacement pod is ready.
