### PR TITLE
OCPBUGS-65984: Prevent AvailableReplicas from dropping to 0 during deployment rollout

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
     app: migrator
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: migrator


### PR DESCRIPTION
 The fix addresses OCPBUGS-65984 by making the kube-storage-version-migrator deployment highly available:

  -  Ensures at least one pod is always available
  - RollingUpdate strategy: Configured with maxUnavailable: 0 and maxSurge: 1
  - Zero downtime updates: During rolling updates, one replica stays available while the other updates, preventing Available=False transitions

  This satisfies the SLO requirement that "ClusterOperator should not report Available=False during normal updates.