### PR TITLE
OCPBUGS-65984: Prevent AvailableReplicas from dropping to 0 during deployment rollout 

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: migrator
 spec:
   replicas: 1
+  minReadySeconds: 30
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
OCPBUGS-65984: Prevent AvailableReplicas from dropping to 0 during deployment rollout 