### PR TITLE
OCPBUGS-65984: Revert TRT-2577: Revert #139 "OCPBUGS-65984: scale migrator deployment"

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -73,11 +73,13 @@ spec:
       terminationGracePeriodSeconds: 30
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - migrator
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - migrator

--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: migrator
 spec:
   replicas: 1
-  minReadySeconds: 30
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -32,14 +31,21 @@ spec:
       containers:
       - name: migrator
         image: ${IMAGE}
-        command: [ "/bin/bash", "-c"]
+        command:
+          - migrator
         args:
-          - |-
-            trap 'echo "Termination signal received, but ignored. Continuing..."; sleep infinity' TERM
-            migrator "$@" & wait $!
-          - bash
           - '--alsologtostderr'
+          - '--leader-election'
           - '--v=2'
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         terminationMessagePolicy: FallbackToLogsOnError
         resources:
             requests:
@@ -50,24 +56,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          runAsUser: 1001
-      - name: graceful-termination
-        image: ${IMAGE}
-        command: [ "/bin/bash", "-c" ]
-        args:
-          - |-
-            trap 'echo "Gracefully sleeping for 25s to let another pod start..."; sleep 25; exit' EXIT
-            while true; do echo "Waiting for termination..."; sleep 3600 & wait $!; done
-        terminationMessagePolicy: FallbackToLogsOnError
-        resources:
-          requests:
-            cpu: 1m
-            memory: 1Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
           runAsUser: 1001
       priorityClassName: system-cluster-critical
       tolerations:
@@ -83,3 +71,13 @@ spec:
           effect: NoExecute
           tolerationSeconds: 120
       terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - migrator

--- a/pkg/operator/deploymentcontroller/deployment.go
+++ b/pkg/operator/deploymentcontroller/deployment.go
@@ -124,7 +124,7 @@ func setDesiredReplicas(infrastructureLister configv1listers.InfrastructureListe
 			if err != nil {
 				return err
 			}
-			replicas = int32(len(nodes))
+			replicas = max(int32(len(nodes)), 1)
 		}
 
 		deployment.Spec.Replicas = &replicas

--- a/pkg/operator/deploymentcontroller/deployment.go
+++ b/pkg/operator/deploymentcontroller/deployment.go
@@ -7,7 +7,10 @@ import (
 	"slices"
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/cluster-kube-storage-version-migrator-operator/bindata"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/deploymentcontroller"
@@ -15,7 +18,10 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	"github.com/openshift/cluster-kube-storage-version-migrator-operator/pkg"
 )
@@ -24,8 +30,9 @@ func NewMigratorDeploymentController(
 	kubeClient kubernetes.Interface,
 	operatorClient v1helpers.OperatorClientWithFinalizers,
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
-	recorder events.Recorder,
-) factory.Controller {
+	nodeInformer corev1informers.NodeInformer,
+	infrastructureInformer configv1informers.InfrastructureInformer,
+	recorder events.Recorder) factory.Controller {
 	return deploymentcontroller.NewDeploymentController(
 		"KubeStorageVersionMigrator",
 		bindata.MustAsset("kube-storage-version-migrator/deployment.yaml"),
@@ -35,11 +42,14 @@ func NewMigratorDeploymentController(
 		kubeInformersForNamespaces.InformersFor(pkg.TargetNamespace).Apps().V1().Deployments(),
 		[]factory.Informer{
 			kubeInformersForNamespaces.InformersFor(pkg.TargetNamespace).Core().V1().Secrets().Informer(),
+			nodeInformer.Informer(),
+			infrastructureInformer.Informer(),
 		},
 		[]deploymentcontroller.ManifestHookFunc{
 			replaceAll("${IMAGE}", os.Getenv("IMAGE")),
 		},
 		setOperandLogLevel,
+		setDesiredReplicas(infrastructureInformer.Lister(), nodeInformer.Lister()),
 	)
 }
 
@@ -85,4 +95,39 @@ func setOperandLogLevel(spec *operatorv1.OperatorSpec, deployment *appsv1.Deploy
 	// --v not found, append to args
 	container.Args = append(container.Args, logLevelArg)
 	return nil
+}
+
+func setDesiredReplicas(infrastructureLister configv1listers.InfrastructureLister, nodeLister corev1listers.NodeLister) deploymentcontroller.DeploymentHookFunc {
+	selector, err := labels.Parse("node-role.kubernetes.io/control-plane")
+	if err != nil {
+		panic(err)
+	}
+	return func(spec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		infra, err := infrastructureLister.Get("cluster")
+		if err != nil {
+			return fmt.Errorf("failed to get infrastructure resource: %w", err)
+		}
+
+		var replicas int32
+		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+			// On HyperShift (External topology), control-plane nodes are not
+			// visible in the guest cluster, so we cannot count them. Default
+			// to 2 replicas for high availability.
+			replicas = 2
+		} else {
+			// Count control-plane nodes to determine the replica count.
+			// We don't use deployment.Spec.Template.Spec.NodeSelector (as
+			// library-go's WithReplicasHook does) because the deployment
+			// does not have a nodeSelector. A previous attempt to add one
+			// broke HyperShift (https://issues.redhat.com/browse/OCPBUGS-18125).
+			nodes, err := nodeLister.List(selector)
+			if err != nil {
+				return err
+			}
+			replicas = int32(len(nodes))
+		}
+
+		deployment.Spec.Replicas = &replicas
+		return nil
+	}
 }

--- a/pkg/operator/deploymentcontroller/deployment_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_test.go
@@ -4,9 +4,15 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 func Test_setOperandLogLevel(t *testing.T) {
@@ -96,4 +102,134 @@ func Test_setOperandLogLevel(t *testing.T) {
 		}
 	})
 
+}
+
+func fakeNodeLister(nodes ...*corev1.Node) corev1listers.NodeLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, n := range nodes {
+		_ = indexer.Add(n)
+	}
+	return corev1listers.NewNodeLister(indexer)
+}
+
+func fakeInfrastructureLister(infra *configv1.Infrastructure) configv1listers.InfrastructureLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	_ = indexer.Add(infra)
+	return configv1listers.NewInfrastructureLister(indexer)
+}
+
+func newControlPlaneNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+		},
+	}
+}
+
+func newInfrastructure(topology configv1.TopologyMode) *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.InfrastructureStatus{
+			ControlPlaneTopology: topology,
+		},
+	}
+}
+
+func Test_setDesiredReplicas(t *testing.T) {
+	testCases := []struct {
+		name             string
+		topology         configv1.TopologyMode
+		nodes            []*corev1.Node
+		expectedReplicas int32
+	}{
+		{
+			name:     "HighlyAvailable with 3 control-plane nodes",
+			topology: configv1.HighlyAvailableTopologyMode,
+			nodes: []*corev1.Node{
+				newControlPlaneNode("master-0"),
+				newControlPlaneNode("master-1"),
+				newControlPlaneNode("master-2"),
+			},
+			expectedReplicas: 3,
+		},
+		{
+			name:             "SingleReplica with 1 control-plane node",
+			topology:         configv1.SingleReplicaTopologyMode,
+			nodes:            []*corev1.Node{newControlPlaneNode("master-0")},
+			expectedReplicas: 1,
+		},
+		{
+			name:             "External topology defaults to 2",
+			topology:         configv1.ExternalTopologyMode,
+			nodes:            nil,
+			expectedReplicas: 2,
+		},
+		{
+			name:     "External topology ignores visible nodes",
+			topology: configv1.ExternalTopologyMode,
+			nodes: []*corev1.Node{
+				newControlPlaneNode("master-0"),
+				newControlPlaneNode("master-1"),
+				newControlPlaneNode("master-2"),
+			},
+			expectedReplicas: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			nodeLister := fakeNodeLister(tc.nodes...)
+			infraLister := fakeInfrastructureLister(newInfrastructure(tc.topology))
+
+			hook := setDesiredReplicas(infraLister, nodeLister)
+
+			deployment := &appsv1.Deployment{}
+			if err := hook(&operatorv1.OperatorSpec{}, deployment); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if deployment.Spec.Replicas == nil {
+				t.Fatal("expected replicas to be set")
+			}
+			if *deployment.Spec.Replicas != tc.expectedReplicas {
+				t.Fatalf("expected %d replicas, got %d", tc.expectedReplicas, *deployment.Spec.Replicas)
+			}
+		})
+	}
+}
+
+// Verify fakeNodeLister only returns nodes matching the control-plane selector.
+func Test_setDesiredReplicas_nodeFiltering(t *testing.T) {
+	// The node lister in setDesiredReplicas uses a label selector, but our fake
+	// lister returns all indexed nodes. This test documents that in production
+	// the informer's list options filter nodes, and the lister's List(selector)
+	// additionally filters. We test with the selector to ensure correctness.
+	nodes := []*corev1.Node{
+		newControlPlaneNode("master-0"),
+		{ObjectMeta: metav1.ObjectMeta{Name: "worker-0", Labels: map[string]string{"node-role.kubernetes.io/worker": ""}}},
+		newControlPlaneNode("master-1"),
+		newControlPlaneNode("master-2"),
+	}
+
+	// Build a real indexer with all nodes to test the label selector in setDesiredReplicas
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, n := range nodes {
+		objs := []runtime.Object{n}
+		for _, o := range objs {
+			_ = indexer.Add(o)
+		}
+	}
+	nodeLister := corev1listers.NewNodeLister(indexer)
+	infraLister := fakeInfrastructureLister(newInfrastructure(configv1.HighlyAvailableTopologyMode))
+
+	hook := setDesiredReplicas(infraLister, nodeLister)
+
+	deployment := &appsv1.Deployment{}
+	if err := hook(&operatorv1.OperatorSpec{}, deployment); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The label selector inside setDesiredReplicas filters to control-plane nodes only
+	if *deployment.Spec.Replicas != 3 {
+		t.Fatalf("expected 3 replicas (control-plane nodes only), got %d", *deployment.Spec.Replicas)
+	}
 }

--- a/pkg/operator/deploymentcontroller/deployment_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_test.go
@@ -175,6 +175,12 @@ func Test_setDesiredReplicas(t *testing.T) {
 			},
 			expectedReplicas: 2,
 		},
+		{
+			name:             "HighlyAvailable with no nodes defaults to 1",
+			topology:         configv1.HighlyAvailableTopologyMode,
+			nodes:            nil,
+			expectedReplicas: 1,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/cluster-kube-storage-version-migrator-operator/bindata"
@@ -80,14 +81,22 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		cc.EventRecorder,
 	)
 
+	nodeInformer := informers.NewSharedInformerFactoryWithOptions(
+		kubeClient, 10*time.Minute,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = "node-role.kubernetes.io/control-plane"
+		}))
+
+	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
+
 	migratorDeploymentController := deploymentcontroller.NewMigratorDeploymentController(
 		kubeClient,
 		operatorClient,
 		kubeInformersForNamespaces,
+		nodeInformer.Core().V1().Nodes(),
+		configInformers.Config().V1().Infrastructures(),
 		cc.EventRecorder,
 	)
-
-	configInformers := configinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
 
 	statusController := status.NewClusterOperatorStatusController(
 		"kube-storage-version-migrator",
@@ -121,6 +130,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	configInformers.Start(ctx.Done())
 	dynamicInformers.Start(ctx.Done())
 	kubeInformersForNamespaces.Start(ctx.Done())
+	nodeInformer.Start(ctx.Done())
 
 	go statusController.Run(ctx, 1)
 	go staticResourceController.Run(ctx, 1)


### PR DESCRIPTION
- **Reapply "Merge pull request #139 from sanchezl/scale-migrator-deployment"**
- **use preferred pod anti-affinity for SNO compatibility**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pod anti-affinity to spread migrator pods across hosts
  * Dynamic replica scaling based on cluster topology, infrastructure mode, and control-plane node count
  * Pod exposes POD_NAME and POD_NAMESPACE environment variables

* **Bug Fixes / Behavior**
  * Simplified migrator container startup and shutdown; removed separate graceful-termination container and shell-based wrapping

* **Tests**
  * Added unit tests covering replica decision logic and node filtering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->