### PR TITLE
OCPBUGS-51091: schedule migrator pods on control-plane nodes

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -62,6 +62,9 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
         - key: node.kubernetes.io/unreachable
           operator: Exists
           effect: NoExecute

--- a/bindata/kube-storage-version-migrator/namespace.yaml
+++ b/bindata/kube-storage-version-migrator/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: openshift-kube-storage-version-migrator
   annotations:
+    openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -72,6 +72,9 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/unreachable
         operator: Exists

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -68,7 +68,7 @@ spec:
           configMap:
             name: config
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: "system-cluster-critical"
       securityContext:
         runAsNonRoot: true
@@ -76,6 +76,9 @@ spec:
           type: RuntimeDefault
       tolerations:
       - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node-role.kubernetes.io/control-plane"
         operator: "Exists"
         effect: "NoSchedule"
       - key: "node.kubernetes.io/unreachable"

--- a/pkg/operator/deploymentcontroller/deployment.go
+++ b/pkg/operator/deploymentcontroller/deployment.go
@@ -50,6 +50,7 @@ func NewMigratorDeploymentController(
 		},
 		setOperandLogLevel,
 		setDesiredReplicas(infrastructureInformer.Lister(), nodeInformer.Lister()),
+		setControlPlaneNodeSelector(infrastructureInformer.Lister()),
 	)
 }
 
@@ -97,6 +98,26 @@ func setOperandLogLevel(spec *operatorv1.OperatorSpec, deployment *appsv1.Deploy
 	return nil
 }
 
+func setControlPlaneNodeSelector(infrastructureLister configv1listers.InfrastructureLister) deploymentcontroller.DeploymentHookFunc {
+	return func(spec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		infra, err := infrastructureLister.Get("cluster")
+		if err != nil {
+			return fmt.Errorf("failed to get infrastructure resource: %w", err)
+		}
+		// On HyperShift (External topology), no nodes carry control-plane
+		// labels in the guest cluster, so a nodeSelector would leave pods
+		// permanently Pending.
+		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
+			return nil
+		}
+		if deployment.Spec.Template.Spec.NodeSelector == nil {
+			deployment.Spec.Template.Spec.NodeSelector = make(map[string]string)
+		}
+		deployment.Spec.Template.Spec.NodeSelector["node-role.kubernetes.io/control-plane"] = ""
+		return nil
+	}
+}
+
 func setDesiredReplicas(infrastructureLister configv1listers.InfrastructureLister, nodeLister corev1listers.NodeLister) deploymentcontroller.DeploymentHookFunc {
 	selector, err := labels.Parse("node-role.kubernetes.io/control-plane")
 	if err != nil {
@@ -116,10 +137,9 @@ func setDesiredReplicas(infrastructureLister configv1listers.InfrastructureListe
 			replicas = 2
 		} else {
 			// Count control-plane nodes to determine the replica count.
-			// We don't use deployment.Spec.Template.Spec.NodeSelector (as
-			// library-go's WithReplicasHook does) because the deployment
-			// does not have a nodeSelector. A previous attempt to add one
-			// broke HyperShift (https://issues.redhat.com/browse/OCPBUGS-18125).
+			// We count nodes directly rather than relying on the deployment's
+			// NodeSelector (as library-go's WithReplicasHook does) because the
+			// nodeSelector is only set conditionally (see setControlPlaneNodeSelector).
 			nodes, err := nodeLister.List(selector)
 			if err != nil {
 				return err

--- a/pkg/operator/deploymentcontroller/deployment_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_test.go
@@ -204,6 +204,45 @@ func Test_setDesiredReplicas(t *testing.T) {
 	}
 }
 
+func Test_setControlPlaneNodeSelector(t *testing.T) {
+	testCases := []struct {
+		name             string
+		topology         configv1.TopologyMode
+		expectedSelector map[string]string
+	}{
+		{
+			name:             "HighlyAvailable sets control-plane nodeSelector",
+			topology:         configv1.HighlyAvailableTopologyMode,
+			expectedSelector: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+		},
+		{
+			name:             "SingleReplica sets control-plane nodeSelector",
+			topology:         configv1.SingleReplicaTopologyMode,
+			expectedSelector: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+		},
+		{
+			name:             "External topology does not set nodeSelector",
+			topology:         configv1.ExternalTopologyMode,
+			expectedSelector: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			infraLister := fakeInfrastructureLister(newInfrastructure(tc.topology))
+			hook := setControlPlaneNodeSelector(infraLister)
+
+			deployment := &appsv1.Deployment{}
+			if err := hook(&operatorv1.OperatorSpec{}, deployment); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedSelector, deployment.Spec.Template.Spec.NodeSelector); diff != "" {
+				t.Fatalf("unexpected nodeSelector (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 // Verify fakeNodeLister only returns nodes matching the control-plane selector.
 func Test_setDesiredReplicas_nodeFiltering(t *testing.T) {
 	// The node lister in setDesiredReplicas uses a label selector, but our fake


### PR DESCRIPTION
## Summary

The migrator deployment had no `nodeSelector`, so pods could land on worker nodes despite being a core control-plane component. Every other OpenShift control-plane operator pins its operand to control-plane nodes via `nodeSelector`, but the migrator was the exception after a previous attempt ([PR #92](https://github.com/openshift/cluster-kube-storage-version-migrator-operator/pull/92)) was [reverted](https://github.com/openshift/cluster-kube-storage-version-migrator-operator/pull/93) because it broke HyperShift (no control-plane nodes exist in guest clusters).

This PR adds a topology-aware `DeploymentHookFunc` that:
- Sets `nodeSelector: node-role.kubernetes.io/control-plane` for all topologies **except** External (HyperShift), where it is skipped to avoid pods remaining Pending
- Adds `openshift.io/node-selector: ""` to the operand namespace to prevent cluster-level `defaultNodeSelector` from constraining migrator pods to non-control-plane nodes
- Adds the `node-role.kubernetes.io/control-plane` toleration alongside the existing `master` toleration for forward compatibility
- Updates the operator deployment `nodeSelector` from `master` to `control-plane`

### Changes
- **`bindata/.../namespace.yaml`** — add `openshift.io/node-selector: ""` annotation to override `defaultNodeSelector`
- **`bindata/.../deployment.yaml`** — add `control-plane` toleration alongside existing `master`
- **`manifests/07_deployment.yaml`** — operator `nodeSelector` `master` → `control-plane`; add `control-plane` toleration alongside existing `master`
- **`manifests/07_deployment-ibm-cloud-managed.yaml`** — add `control-plane` toleration alongside existing `master` (generated via `make update`)
- **`pkg/operator/deploymentcontroller/deployment.go`** — new `setControlPlaneNodeSelector` hook
- **`pkg/operator/deploymentcontroller/deployment_test.go`** — unit tests for HA, SNO, and External topologies

## Test plan
- [x] Unit tests pass for `setControlPlaneNodeSelector` across HA, SNO, and External topologies
- [ ] CI e2e passes (standard HA topology)
- [ ] Verify with `/payload-job` on SNO and HyperShift topologies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scheduling storage version migrator workloads on control-plane nodes, with topology-aware configuration that adapts based on cluster topology mode.

* **Chores**
  * Updated deployment manifests to include control-plane node tolerations and selectors alongside existing master node configurations.
  * Added namespace annotation for node selector configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->