### PR TITLE
OCPBUGS-65984: add PodDisruptionBudget for migrator deployment

### DIFF
--- a/bindata/kube-storage-version-migrator/pdb.yaml
+++ b/bindata/kube-storage-version-migrator/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: migrator
+  namespace: openshift-kube-storage-version-migrator
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: migrator

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -78,6 +78,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 			"kube-storage-version-migrator/roles.yaml",
 			"kube-storage-version-migrator/networkpolicy-allow.yaml",
 			"kube-storage-version-migrator/networkpolicy-default-deny.yaml",
+			"kube-storage-version-migrator/pdb.yaml",
 		},
 		(&resourceapply.ClientHolder{}).WithKubernetes(kubeClient),
 		operatorClient,


### PR DESCRIPTION
## Summary

- Add a PodDisruptionBudget with `maxUnavailable: 1` for the migrator deployment to prevent all pods from being evicted simultaneously during MCO node drains

## Problem

During OCP upgrades, MCO drains control-plane nodes using the eviction API. The migrator deployment has preferred (soft) pod anti-affinity, so all 3 replicas can end up on the same node. When that node is drained, all pods are evicted simultaneously — node drain evictions bypass the deployment's `maxUnavailable: 0` (which only governs the deployment controller's own rollouts, not the eviction API). This causes `AvailableReplicas` to drop to zero and the operator reports `Available=False`.

## Fix

A PodDisruptionBudget with `maxUnavailable: 1` limits concurrent evictions so drain can only remove one migrator pod at a time. This keeps the deployment available throughout the upgrade.

`maxUnavailable: 1` works for all topologies:
- **HA (3 replicas):** drain evicts 1 at a time, minimum 2 remain available
- **SNO (1 replica):** `disruptionsAllowed = 1 - (1-1) = 1`, allows the single pod to be evicted (MCO also skips drain entirely on SNO)

## Test plan

- [ ] CI presubmit jobs pass (e2e-aws, e2e-aws-operator, e2e-gcp-operator, e2e-gcp-operator-disruptive, unit, verify)
- [ ] Payload test with upgrade job to verify Available=False no longer occurs during node drain
- [ ] Verify SNO upgrade is not blocked by the PDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pod Disruption Budget protection for the kube-storage-version-migrator component, ensuring at most one pod remains unavailable during cluster maintenance and planned disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->