### PR TITLE
STOR-2954: feat: have CVO inject the centralized TLS configuration into the operator's config

### DIFF
--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -7,7 +7,8 @@ metadata:
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    config.openshift.io/inject-tls: "true"
 data:
   config.yaml: |
-    apiVersion: operator.openshift.io/v1
+    apiVersion: operator.openshift.io/v1alpha1
     kind: GenericOperatorConfig

--- a/manifests/07_deployment-ibm-cloud-managed.yaml
+++ b/manifests/07_deployment-ibm-cloud-managed.yaml
@@ -28,6 +28,7 @@ spec:
       containers:
       - args:
         - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         command:
         - cluster-kube-storage-version-migrator-operator
         - start

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -35,6 +35,7 @@ spec:
         command: ["cluster-kube-storage-version-migrator-operator", "start"]
         args:
           - "--config=/var/run/configmaps/config/config.yaml"
+          - "--terminate-on-files=/var/run/configmaps/config/config.yaml"
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
Also, have the operator restart whenever the config changes.

wip-docs: https://github.com/openshift/enhancements/pull/2020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled TLS injection for secure configuration management
  * Updated operator configuration API version for improved compatibility
  * Configured deployments to automatically terminate and reload on configuration file changes for graceful updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->