### PR TITLE
OCPBUGS-65984: use topology-aware scheduling for migrator deployment

### DIFF
--- a/bindata/kube-storage-version-migrator/deployment.yaml
+++ b/bindata/kube-storage-version-migrator/deployment.yaml
@@ -10,8 +10,10 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
+      # The operator dynamically adjusts maxSurge, maxUnavailable,
+      # and pod anti-affinity based on ControlPlaneTopology.
       maxSurge: 1
-      maxUnavailable: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: migrator
@@ -74,15 +76,3 @@ spec:
           effect: NoExecute
           tolerationSeconds: 120
       terminationGracePeriodSeconds: 30
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - migrator

--- a/pkg/operator/deploymentcontroller/deployment.go
+++ b/pkg/operator/deploymentcontroller/deployment.go
@@ -18,7 +18,9 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -51,6 +53,7 @@ func NewMigratorDeploymentController(
 		setOperandLogLevel,
 		setDesiredReplicas(infrastructureInformer.Lister(), nodeInformer.Lister()),
 		setControlPlaneNodeSelector(infrastructureInformer.Lister()),
+		setSchedulingStrategy,
 	)
 }
 
@@ -130,24 +133,61 @@ func setDesiredReplicas(infrastructureLister configv1listers.InfrastructureListe
 		}
 
 		var replicas int32
-		if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
-			// On HyperShift (External topology), control-plane nodes are not
-			// visible in the guest cluster, so we cannot count them. Default
-			// to 2 replicas for high availability.
+		switch infra.Status.ControlPlaneTopology {
+		case configv1.SingleReplicaTopologyMode:
+			replicas = 1
+		case configv1.DualReplicaTopologyMode, configv1.HighlyAvailableArbiterMode, configv1.ExternalTopologyMode:
 			replicas = 2
-		} else {
-			// Count control-plane nodes to determine the replica count.
-			// We count nodes directly rather than relying on the deployment's
-			// NodeSelector (as library-go's WithReplicasHook does) because the
-			// nodeSelector is only set conditionally (see setControlPlaneNodeSelector).
+		case configv1.HighlyAvailableTopologyMode:
+			replicas = 3
+		default:
 			nodes, err := nodeLister.List(selector)
 			if err != nil {
 				return err
 			}
-			replicas = max(int32(len(nodes)), 1)
+			replicas = min(max(int32(len(nodes)), 1), 3)
 		}
-
 		deployment.Spec.Replicas = &replicas
 		return nil
 	}
+}
+
+func setSchedulingStrategy(spec *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+	replicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = *deployment.Spec.Replicas
+	}
+
+	if deployment.Spec.Strategy.RollingUpdate == nil {
+		deployment.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{}
+	}
+	maxUnavailable := intstr.FromInt32(max(replicas-1, 1))
+	maxSurge := intstr.FromInt32(1)
+	deployment.Spec.Strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
+	deployment.Spec.Strategy.RollingUpdate.MaxSurge = &maxSurge
+
+	if replicas > 1 {
+		deployment.Spec.Template.Spec.Affinity = &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					{
+						TopologyKey: "kubernetes.io/hostname",
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"migrator"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	} else {
+		deployment.Spec.Template.Spec.Affinity = nil
+	}
+
+	return nil
 }

--- a/pkg/operator/deploymentcontroller/deployment_test.go
+++ b/pkg/operator/deploymentcontroller/deployment_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -176,8 +177,54 @@ func Test_setDesiredReplicas(t *testing.T) {
 			expectedReplicas: 2,
 		},
 		{
-			name:             "HighlyAvailable with no nodes defaults to 1",
-			topology:         configv1.HighlyAvailableTopologyMode,
+			name:     "DualReplica with 2 control-plane nodes",
+			topology: configv1.DualReplicaTopologyMode,
+			nodes: []*corev1.Node{
+				newControlPlaneNode("master-0"),
+				newControlPlaneNode("master-1"),
+			},
+			expectedReplicas: 2,
+		},
+		{
+			name:     "HighlyAvailableArbiter with 3 nodes caps at 2",
+			topology: configv1.HighlyAvailableArbiterMode,
+			nodes: []*corev1.Node{
+				newControlPlaneNode("master-0"),
+				newControlPlaneNode("master-1"),
+				newControlPlaneNode("arbiter-0"),
+			},
+			expectedReplicas: 2,
+		},
+		{
+			name:     "HighlyAvailable with 5 nodes caps at 3",
+			topology: configv1.HighlyAvailableTopologyMode,
+			nodes: []*corev1.Node{
+				newControlPlaneNode("master-0"),
+				newControlPlaneNode("master-1"),
+				newControlPlaneNode("master-2"),
+				newControlPlaneNode("master-3"),
+				newControlPlaneNode("master-4"),
+			},
+			expectedReplicas: 3,
+		},
+		{
+			name:     "Unknown topology with 2 nodes gets 2 replicas",
+			topology: configv1.TopologyMode("SomeNewTopology"),
+			nodes: []*corev1.Node{
+				newControlPlaneNode("master-0"),
+				newControlPlaneNode("master-1"),
+			},
+			expectedReplicas: 2,
+		},
+		{
+			name:             "Unknown topology with 1 node gets 1 replica",
+			topology:         configv1.TopologyMode("SomeNewTopology"),
+			nodes:            []*corev1.Node{newControlPlaneNode("master-0")},
+			expectedReplicas: 1,
+		},
+		{
+			name:             "Unknown topology with 0 nodes gets 1 replica",
+			topology:         configv1.TopologyMode("SomeNewTopology"),
 			nodes:            nil,
 			expectedReplicas: 1,
 		},
@@ -277,4 +324,94 @@ func Test_setDesiredReplicas_nodeFiltering(t *testing.T) {
 	if *deployment.Spec.Replicas != 3 {
 		t.Fatalf("expected 3 replicas (control-plane nodes only), got %d", *deployment.Spec.Replicas)
 	}
+}
+
+func Test_setSchedulingStrategy(t *testing.T) {
+	requiredAntiAffinity := &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					TopologyKey: "kubernetes.io/hostname",
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"migrator"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name               string
+		replicas           *int32
+		expectedAffinity   *corev1.Affinity
+		expectedMaxUnavail intstr.IntOrString
+		expectedMaxSurge   intstr.IntOrString
+	}{
+		{
+			name:               "1 replica clears affinity",
+			replicas:           ptr(int32(1)),
+			expectedAffinity:   nil,
+			expectedMaxUnavail: intstr.FromInt32(1),
+			expectedMaxSurge:   intstr.FromInt32(1),
+		},
+		{
+			name:               "2 replicas sets required anti-affinity",
+			replicas:           ptr(int32(2)),
+			expectedAffinity:   requiredAntiAffinity,
+			expectedMaxUnavail: intstr.FromInt32(1),
+			expectedMaxSurge:   intstr.FromInt32(1),
+		},
+		{
+			name:               "3 replicas sets required anti-affinity with maxUnavailable 2",
+			replicas:           ptr(int32(3)),
+			expectedAffinity:   requiredAntiAffinity,
+			expectedMaxUnavail: intstr.FromInt32(2),
+			expectedMaxSurge:   intstr.FromInt32(1),
+		},
+		{
+			name:               "nil replicas treated as 1",
+			replicas:           nil,
+			expectedAffinity:   nil,
+			expectedMaxUnavail: intstr.FromInt32(1),
+			expectedMaxSurge:   intstr.FromInt32(1),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			deployment := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: tc.replicas,
+					Strategy: appsv1.DeploymentStrategy{
+						Type:          appsv1.RollingUpdateDeploymentStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDeployment{},
+					},
+				},
+			}
+
+			if err := setSchedulingStrategy(&operatorv1.OperatorSpec{}, deployment); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedAffinity, deployment.Spec.Template.Spec.Affinity); diff != "" {
+				t.Fatalf("unexpected affinity (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedMaxUnavail, *deployment.Spec.Strategy.RollingUpdate.MaxUnavailable); diff != "" {
+				t.Fatalf("unexpected maxUnavailable (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedMaxSurge, *deployment.Spec.Strategy.RollingUpdate.MaxSurge); diff != "" {
+				t.Fatalf("unexpected maxSurge (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }


### PR DESCRIPTION
## Summary
- Replace static preferred pod anti-affinity with required anti-affinity set dynamically by `setSchedulingStrategy` based on the replica count
- Rewrite `setDesiredReplicas` to use an explicit `ControlPlaneTopology` switch (SNO→1, DualReplica/TNA/HyperShift→2, HA→3) with a node-counting fallback for unknown topologies
- Change deployment manifest default `maxUnavailable` from 0 to 1, and dynamically scale it to `replicas-1` at runtime to prevent rolling update deadlocks with required anti-affinity

## Test plan
- [x] Unit tests pass (`go test ./pkg/operator/deploymentcontroller/...`)
- [ ] SNO upgrade — verify no deadlock with required anti-affinity + maxUnavailable=1
- [ ] Two-node fencing — verify pods spread across nodes and survive fencing
- [ ] HA upgrade — standard CI
- [ ] HyperShift — verify 2-replica External topology

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Kube-storage-version-migrator now auto-adjusts replica count based on control-plane topology (single→1, dual/arbiter/external→2, highly-available→3; sensible fallback).
  * Rolling update behavior tuned to preserve availability (maxUnavailable=1, maxSurge=1).
  * Pod scheduling simplified: distribution enforced when multiple replicas exist; single-replica pods use relaxed scheduling.

* **Tests**
  * Added coverage validating replica calculations, rolling-update settings, and scheduling/anti-affinity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->